### PR TITLE
Support not running in Admin mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,6 +31,8 @@ def get_egs_manifest_directory():
 
         except FileNotFoundError:
             continue
+        except PermissionError:
+            continue
 
     return None
 


### PR DESCRIPTION
This fixes #2 where the script fails if it is ran in non-admin mode when there are multiple user accounts, or the useraccount is at the bottom of the user registry hive.